### PR TITLE
Simplify postal code regex

### DIFF
--- a/src/Provider/nl_NL/HealthCareTeams.php
+++ b/src/Provider/nl_NL/HealthCareTeams.php
@@ -204,7 +204,7 @@ class HealthCareTeams extends HealthCareTeamsBase
 
     public function postalCodeNl(): string
     {
-        return $this->faker->regexify('/^[1-9][0-9]{3} ?(?!sa|sd|ss)[a-z]{2}$/i');
+        return $this->faker->regexify('[1-9][0-9]{3} [A-Z]{2}');
     }
 
     public function parseFromProperty(string $string): string


### PR DESCRIPTION
Currently the `regexify` in `postalCodeNl()` can result in the following postal code which (I think) is not a valid dutch postal code.

![image](https://github.com/user-attachments/assets/8e8a34ba-d44c-4587-a873-9752ae423d3b)

This PR should fix that.